### PR TITLE
remove the pre-include prefix 'cv' of bilibili id

### DIFF
--- a/bilibili.py
+++ b/bilibili.py
@@ -62,7 +62,7 @@ def bilibili_spider(cfg):
     for id in cfg.ids:
         if id == '':
             continue
-        url = f'https://www.bilibili.com/read/cv{id}'
+        url = f'https://www.bilibili.com/read/{id}'
         spider = Crawler(cfg)
         get_meta(spider,url)
         spider.generator('bilibili')


### PR DESCRIPTION
Remove the pre-include prefix 'cv' of bilibili id in code, so that the user can paste the whole id including the prefix as argument, which can be copied by just double click the field in the URL.